### PR TITLE
add overflow to idea title and shorten width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -111,6 +111,8 @@ textarea{
   color: #6D6E71;
   display: inline-block;
   font-size: 40px;
+  overflow: visible;
+  width: 95%;
 }
 
 .upvote:hover, .downvote:hover, .delete-idea:hover {


### PR DESCRIPTION
changed the css for the idea-title to be 95% wide and overflow: visible (instead of scroll). This allows the title to wrap and doesn't adjust the placement of the delete button. Take a look and see if you guys like it. Works better than the scroll and very unlikely a title will be long enough to wrap anyway. 
